### PR TITLE
Change URL to official Tabler Icons website

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If this project help you reduce time to develop, you can give me a cup of coffee
 
 ## Credits 🤗
 
-- Icons are from [tablericons.com](https://tablericons.com)
+- Icons are from [Tabler Icons](https://tabler.io/icons)
 - Heartly congratulations for Jetpack Compose Team who worked hard to make Compose great ♥️
 
 


### PR DESCRIPTION
Hi, I hope you’re doing well!

I wanted to kindly ask if you could update the link to Tabler Icons to the correct URL: https://tabler.io/icons.

The current site, tablericons. com, isn’t affiliated with the Tabler Icons project. The person behind it is misleading users by claiming to be the author of the library. You can verify the official project and its details here: https://github.com/tabler/tabler-icons.

Thanks so much for your understanding and for supporting accurate representation of the Tabler project!

Best regards
Bartek, co-owner of https://github.com/tabler
